### PR TITLE
start = time.mktime(start.timetuple()) didn't take into account timez…

### DIFF
--- a/poloniex/api/base.py
+++ b/poloniex/api/base.py
@@ -60,11 +60,11 @@ class BasePublicApi:
 
         start = kwargs.get("start")
         if start:
-            start = time.mktime(start.timetuple())
+            start = start.timestamp()
 
         end = kwargs.get("end")
         if end:
-            end = time.mktime(end.timetuple())
+            end = end.timestamp()
 
         period = kwargs.get("period")
         if period and period not in constants.CHART_DATA_PERIODS:
@@ -166,11 +166,11 @@ class BaseTradingApi:
 
         start = kwargs.get("start")
         if start:
-            start = time.mktime(start.timetuple()),
+            start = start.timestamp()
 
         end = kwargs.get("end")
         if end:
-            end = time.mktime(end.timetuple())
+            end = end.timestamp()
 
         rate = kwargs.get("rate")
         amount = kwargs.get("amount")


### PR DESCRIPTION
The code uses "start = time.mktime(start.timetuple())" to determine UNIX timestamps.

This doesn't however take into account timezone aware datetime objects - for the above approach the timezone is dropped.

Replaced this with a call to datetime.timestamp() and the timezone is no longer dropped